### PR TITLE
Top caption placement for parametertable

### DIFF
--- a/R/parametertable.R
+++ b/R/parametertable.R
@@ -60,5 +60,6 @@ parametertable <- function (data,
         include.rownames = FALSE,
         sanitize.colnames.function=function(x) paste('{\\textbf{',x,'}}', sep =''),
         sanitize.text.function= function(x) x,
-        table.placement = "H")
+        table.placement = "H",
+        caption.placement = "top")
 }


### PR DESCRIPTION
Set the caption placement in parametertable to be at the top instead of defaulting to the bottom