### PR TITLE
Handle the 'dir' argument in the template() function if it does not end with a '/'

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -174,7 +174,7 @@ template <- function(dir = NULL,
   # ____________________________________
   # Edit Makefile to match fish filename
   # ____________________________________
-  Makefile_path <- paste0(dir,'Makefile')
+  Makefile_path <- file.path(dir, 'makefile')
   Makefile_content <- gsub("template", filename, readLines(Makefile_path))
   writeLines(Makefile_content, Makefile_path) # Write the modified content back to the file
 }


### PR DESCRIPTION
Change the path to the makefile to be via file.path() instead of paste0() so that the 'dir' argument is not required to end with a '/'